### PR TITLE
chore(spring-app): migrate to Spring Boot 3.x, Java 21 and Jakarta APIs

### DIFF
--- a/spring-app/pom.xml
+++ b/spring-app/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.1.4.RELEASE</version>
+		<version>3.5.13</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>net.guides.springboot2</groupId>
@@ -15,7 +15,12 @@
 	<description>Demo project for Spring Boot</description>
 
 	<properties>
-		<java.version>1.8</java.version>
+		<java.version>21</java.version>
+		<maven.compiler.plugin.version>3.13.0</maven.compiler.plugin.version>
+		<maven.surefire.plugin.version>3.5.2</maven.surefire.plugin.version>
+		<maven.failsafe.plugin.version>3.5.2</maven.failsafe.plugin.version>
+		<maven.enforcer.plugin.version>3.5.0</maven.enforcer.plugin.version>
+		<jacoco.maven.plugin.version>0.8.12</jacoco.maven.plugin.version>
 	</properties>
 
 	<dependencies>
@@ -27,6 +32,10 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -34,8 +43,8 @@
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
-			<groupId>mysql</groupId>
-			<artifactId>mysql-connector-java</artifactId>
+			<groupId>com.mysql</groupId>
+			<artifactId>mysql-connector-j</artifactId>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
@@ -52,8 +61,50 @@
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>${maven.compiler.plugin.version}</version>
+				<configuration>
+					<release>${java.version}</release>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>${maven.surefire.plugin.version}</version>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-failsafe-plugin</artifactId>
+				<version>${maven.failsafe.plugin.version}</version>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>${maven.enforcer.plugin.version}</version>
+				<executions>
+					<execution>
+						<id>enforce-java-and-maven</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<requireJavaVersion>
+									<version>[21,22)</version>
+								</requireJavaVersion>
+								<requireMavenVersion>
+									<version>[3.9.0,)</version>
+								</requireMavenVersion>
+							</rules>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>${jacoco.maven.plugin.version}</version>
 				<executions>
 					<execution>
 						<goals>

--- a/spring-app/src/main/java/com/burt/resourcemanagement/controller/ResourceController.java
+++ b/spring-app/src/main/java/com/burt/resourcemanagement/controller/ResourceController.java
@@ -5,7 +5,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;

--- a/spring-app/src/main/java/com/burt/resourcemanagement/controller/TeamController.java
+++ b/spring-app/src/main/java/com/burt/resourcemanagement/controller/TeamController.java
@@ -4,7 +4,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;

--- a/spring-app/src/main/java/com/burt/resourcemanagement/model/Resource.java
+++ b/spring-app/src/main/java/com/burt/resourcemanagement/model/Resource.java
@@ -2,13 +2,13 @@ package com.burt.resourcemanagement.model;
 
 import java.util.Date;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.Table;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Size;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 @Entity
 @Table(name = "resources")

--- a/spring-app/src/main/java/com/burt/resourcemanagement/model/SudoRole.java
+++ b/spring-app/src/main/java/com/burt/resourcemanagement/model/SudoRole.java
@@ -3,14 +3,14 @@ package com.burt.resourcemanagement.model;
 import java.util.Date;
 import java.util.Objects;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.Table;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Size;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 @Entity
 @Table(name="sudoroles")

--- a/spring-app/src/main/java/com/burt/resourcemanagement/model/Team.java
+++ b/spring-app/src/main/java/com/burt/resourcemanagement/model/Team.java
@@ -3,14 +3,14 @@ package com.burt.resourcemanagement.model;
 import java.util.Date;
 import java.util.List;
 
-import javax.persistence.ElementCollection;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.Table;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Size;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 @Entity
 @Table(name = "teams")


### PR DESCRIPTION
### Motivation
- Move the module to a current Spring Boot 3.x baseline and Java 21 so it can take advantage of the modern Spring 6 / Jakarta EE runtime and toolchain.
- Replace `javax.*` usages with `jakarta.*` to align JPA and Bean Validation APIs with the Spring Boot 3 / Jakarta platform.
- Make only mechanical compatibility changes (POM and imports) in a focused migration PR, leaving behavioral/test migrations out of scope.

### Description
- Upgraded `spring-app` parent from Spring Boot `2.1.4.RELEASE` to `3.5.13` and set `<java.version>21</java.version>` in `spring-app/pom.xml`.
- Added explicit Java 21-compatible plugin versions and configuration: `maven-compiler-plugin` (`3.13.0` with `<release>21</release>`), `maven-surefire-plugin` and `maven-failsafe-plugin` (`3.5.2`), and `jacoco` version property.
- Added `maven-enforcer-plugin` execution enforcing Java `[21,22)` and Maven `>= 3.9.0` to ensure environment consistency.
- Added `spring-boot-starter-validation` and switched MySQL driver coordinates to `com.mysql:mysql-connector-j` to align with Boot 3 BOM.
- Replaced `javax.*` imports with `jakarta.*` in the requested files and updated JPA/validation annotations to Jakarta equivalents in `spring-app/src/main/java/com/burt/resourcemanagement/model/*.java` and `spring-app/src/main/java/com/burt/resourcemanagement/controller/*.java`.

### Testing
- Ran compilation with tests skipped using `mvn -f spring-app/pom.xml -Dmaven.test.skip=true compile`, which completed successfully. ✅
- Ran `mvn -f spring-app/pom.xml test -DskipITs`, which failed due to existing test sources using older JUnit 4-style APIs (this PR intentionally scoped to mechanical Boot/Jakarta migration and does not migrate tests). ❌

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea364410a4832a8f9d393b897e5a96)