### PR TITLE
Add dependency governance, React migration baseline, and CI SCA scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/spring-app"
+    schedule:
+      interval: "weekly"
+    groups:
+      spring-boot-core:
+        patterns:
+          - "org.springframework.boot:*"
+      backend-test-and-quality:
+        patterns:
+          - "org.jacoco:*"
+          - "org.junit:*"
+          - "org.mockito:*"
+
+  - package-ecosystem: "npm"
+    directory: "/react-client"
+    schedule:
+      interval: "weekly"
+    groups:
+      react-core:
+        patterns:
+          - "react"
+          - "react-dom"
+      react-tooling:
+        patterns:
+          - "vite"
+          - "@types/*"
+
+  - package-ecosystem: "npm"
+    directory: "/angular-client"
+    schedule:
+      interval: "monthly"
+    ignore:
+      - dependency-name: "*"
+    labels:
+      - "security-only"

--- a/.github/workflows/dependency-governance.yml
+++ b/.github/workflows/dependency-governance.yml
@@ -1,0 +1,57 @@
+name: Dependency Governance
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  policy-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Enforce framework major version policy
+        run: node tools/check-framework-majors.mjs
+
+  backend-sca:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Backend dependency vulnerability scan (OWASP Dependency-Check)
+        run: |
+          cd spring-app
+          ./mvnw -B org.owasp:dependency-check-maven:check
+
+  frontend-sca:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        app: [angular-client, react-client]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        run: npm install
+        working-directory: ${{ matrix.app }}
+
+      - name: Frontend dependency vulnerability scan (npm audit)
+        run: npm audit --audit-level=moderate
+        working-directory: ${{ matrix.app }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # resource-repository
-Resource Management System using Java, Spring, Spring Boot, Angular 7.
+Resource Management System using Java, Spring, Spring Boot, and frontend clients.
 
 This is a resource management application that implements CRUD operations as well as basic search functionality for the model classes of a Resource and a Team, on which a Resource may belong.
 
-There is the potential to update this application with some of the new innovations in this tech stack. However, this is not something I will be working on going forward. 
+## Frontend direction
+
+- `angular-client` is in **security-only** maintenance mode.
+- New frontend feature work should target `react-client`.
+
+See dependency governance and migration details in:
+- `docs/dependency-matrix.md`
+- `docs/dependency-policy.md`

--- a/angular-client/package.json
+++ b/angular-client/package.json
@@ -15,7 +15,7 @@
     "@angular/animations": "~8.2.14",
     "@angular/common": "~8.2.14",
     "@angular/compiler": "~8.2.14",
-    "@angular/core": "~11.0.5",
+    "@angular/core": "~8.2.14",
     "@angular/forms": "~8.2.14",
     "@angular/platform-browser": "~8.2.14",
     "@angular/platform-browser-dynamic": "~8.2.14",

--- a/docs/dependency-matrix.md
+++ b/docs/dependency-matrix.md
@@ -1,0 +1,34 @@
+# Dependency Matrix
+
+This matrix tracks **current** vs **target** versions and status for runtime, test, and build plugin/tooling dependencies across the backend and frontend.
+
+## Backend (`spring-app`)
+
+| Category | Dependency | Current | Target | Notes |
+|---|---|---:|---:|---|
+| Runtime | Spring Boot BOM (`org.springframework.boot:spring-boot-dependencies`) | `2.1.4.RELEASE` (via parent) | `2.7.18` (imported BOM) | Migrated to explicit BOM import for centrally managed versions. |
+| Runtime | `spring-boot-starter-web` | Boot-managed | Boot-managed | Managed through BOM. |
+| Runtime | `spring-boot-starter-data-jpa` | Boot-managed | Boot-managed | Managed through BOM. |
+| Runtime | MySQL JDBC driver | `mysql:mysql-connector-java` | `com.mysql:mysql-connector-j` | Updated to current artifact naming. |
+| Runtime | `spring-boot-devtools` | Boot-managed | Boot-managed | Runtime scope retained. |
+| Test | `spring-boot-starter-test` | Boot-managed | Boot-managed | Test scope retained. |
+| Build Plugin | `spring-boot-maven-plugin` | Parent-managed | BOM-compatible (explicit plugin in build) | Continues packaging and Spring Boot lifecycle integration. |
+| Build Plugin | `jacoco-maven-plugin` | Unpinned | Keep current; review quarterly | Coverage plugin retained; can be pinned later if required by policy. |
+
+## Frontend (`angular-client` and `react-client`)
+
+| Category | Dependency | Current | Target | Notes |
+|---|---|---:|---:|---|
+| Runtime | Angular core framework packages | Mixed majors (`@angular/core` 11, others 8) | Align to major 8 during freeze | Adjusted to avoid mixed major framework core packages. |
+| Runtime | Angular app lifecycle | Active feature development | Security-only maintenance | Angular app is now frozen while React rollout starts. |
+| Runtime | React app | Not present | Introduced (`react`/`react-dom` 18) | New `react-client` workspace added as migration landing zone. |
+| Test | Angular Karma/Jasmine toolchain | Existing | Security updates only | No feature-driven upgrades while frozen. |
+| Build Tool | Angular CLI/Devkit | 8.x | Security updates only | Update policy enforced by Dependabot + freeze policy. |
+| Build Tool | React build tooling (`vite`) | N/A | `vite` 5.x | Baseline for new React app scaffold. |
+| Update Automation | Dependabot | Not configured | Enabled with grouped rules | Backend and frontend ecosystems grouped for controlled update flow. |
+
+## Guardrails and governance
+
+- No mixed major versions are allowed within core framework dependency families (Angular core packages, React core packages).
+- CI includes software composition analysis (SCA) and vulnerability checks for backend and frontend.
+- Angular remains in security-only mode; feature work should target `react-client`.

--- a/docs/dependency-policy.md
+++ b/docs/dependency-policy.md
@@ -1,0 +1,36 @@
+# Dependency Policy
+
+## 1) Framework core major version alignment
+
+The repository must not contain mixed major versions inside a framework core family.
+
+### Angular core family
+- `@angular/animations`
+- `@angular/common`
+- `@angular/compiler`
+- `@angular/core`
+- `@angular/forms`
+- `@angular/platform-browser`
+- `@angular/platform-browser-dynamic`
+- `@angular/router`
+
+### React core family
+- `react`
+- `react-dom`
+
+All packages in a given family must resolve to the same major version.
+
+## 2) Frontend lifecycle
+
+- `angular-client` is in **security-only** maintenance mode.
+- New frontend features must be implemented in `react-client`.
+- Angular dependency upgrades should be limited to security and critical stability fixes.
+
+## 3) Automated updates
+
+- Dependabot is enabled with grouped rules for Maven and npm.
+- Grouped updates reduce PR noise and make coordinated upgrades easier.
+
+## 4) SCA / vulnerability scanning
+
+CI must run backend and frontend dependency vulnerability scans on pull requests and pushes to `main`.

--- a/react-client/README.md
+++ b/react-client/README.md
@@ -1,0 +1,10 @@
+# React Client
+
+This workspace is the new frontend landing zone while `angular-client` is in security-only maintenance.
+
+## Commands
+
+- `npm install`
+- `npm run dev`
+- `npm run build`
+- `npm run audit`

--- a/react-client/index.html
+++ b/react-client/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>React Client</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/react-client/package.json
+++ b/react-client/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "react-client",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "audit": "npm audit --audit-level=moderate"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "vite": "^5.4.11"
+  }
+}

--- a/react-client/src/main.jsx
+++ b/react-client/src/main.jsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+
+function App() {
+  return <h1>React migration workspace</h1>;
+}
+
+createRoot(document.getElementById('root')).render(<App />);

--- a/spring-app/pom.xml
+++ b/spring-app/pom.xml
@@ -1,75 +1,86 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.1.4.RELEASE</version>
-		<relativePath/> <!-- lookup parent from repository -->
-	</parent>
-	<groupId>net.guides.springboot2</groupId>
-	<artifactId>springboot2-jpa-crud-example</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
-	<name>springboot2-jpa-crud-example</name>
-	<description>Demo project for Spring Boot</description>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-	<properties>
-		<java.version>1.8</java.version>
-	</properties>
+    <groupId>net.guides.springboot2</groupId>
+    <artifactId>springboot2-jpa-crud-example</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>springboot2-jpa-crud-example</name>
+    <description>Demo project for Spring Boot</description>
 
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-jpa</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
+    <properties>
+        <java.version>1.8</java.version>
+        <spring.boot.version>2.7.18</spring.boot.version>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
+    </properties>
 
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-devtools</artifactId>
-			<scope>runtime</scope>
-		</dependency>
-		<dependency>
-			<groupId>mysql</groupId>
-			<artifactId>mysql-connector-java</artifactId>
-			<scope>runtime</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring.boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
-			</plugin>
-			<plugin>
-				<groupId>org.jacoco</groupId>
-				<artifactId>jacoco-maven-plugin</artifactId>
-				<executions>
-					<execution>
-						<goals>
-							<goal>prepare-agent</goal>
-						</goals>
-					</execution>
-					<execution>
-						<id>report</id>
-						<phase>test</phase>
-						<goals>
-							<goal>report</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-devtools</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/tools/check-framework-majors.mjs
+++ b/tools/check-framework-majors.mjs
@@ -1,0 +1,79 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const root = process.cwd();
+
+function readJsonIfExists(filePath) {
+  if (!fs.existsSync(filePath)) {
+    return null;
+  }
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function parseMajor(versionRange) {
+  if (!versionRange) return null;
+  const match = versionRange.match(/(\d+)/);
+  return match ? Number(match[1]) : null;
+}
+
+function assertSingleMajor(pkgJsonPath, packageNames, familyName) {
+  const pkgJson = readJsonIfExists(pkgJsonPath);
+  if (!pkgJson) {
+    console.log(`Skipping ${familyName}: ${pkgJsonPath} not found.`);
+    return;
+  }
+
+  const allDeps = {
+    ...(pkgJson.dependencies || {}),
+    ...(pkgJson.devDependencies || {})
+  };
+
+  const majors = new Map();
+
+  for (const packageName of packageNames) {
+    const version = allDeps[packageName];
+    if (!version) continue;
+    const major = parseMajor(version);
+    if (major === null) continue;
+
+    if (!majors.has(major)) majors.set(major, []);
+    majors.get(major).push(`${packageName}@${version}`);
+  }
+
+  if (majors.size <= 1) {
+    console.log(`OK: ${familyName} versions are aligned in ${pkgJsonPath}.`);
+    return;
+  }
+
+  console.error(`ERROR: ${familyName} has mixed major versions in ${pkgJsonPath}:`);
+  for (const [major, entries] of majors.entries()) {
+    console.error(`  major ${major}: ${entries.join(', ')}`);
+  }
+
+  process.exitCode = 1;
+}
+
+assertSingleMajor(
+  path.join(root, 'angular-client', 'package.json'),
+  [
+    '@angular/animations',
+    '@angular/common',
+    '@angular/compiler',
+    '@angular/core',
+    '@angular/forms',
+    '@angular/platform-browser',
+    '@angular/platform-browser-dynamic',
+    '@angular/router'
+  ],
+  'Angular core family'
+);
+
+assertSingleMajor(
+  path.join(root, 'react-client', 'package.json'),
+  ['react', 'react-dom'],
+  'React core family'
+);
+
+if (process.exitCode) {
+  process.exit(process.exitCode);
+}


### PR DESCRIPTION
### Motivation

- Centralize and modernize dependency management for the backend and avoid deprecated artifacts. 
- Freeze the existing Angular app into security-only maintenance and provide a new React workspace as the migration/feature landing zone. 
- Introduce automated dependency updates and grouped rules to reduce noise while enabling coordinated upgrades. 
- Add CI SCA/vulnerability checks and an automated policy check to prevent mixed-major framework core package versions. 

### Description

- Added `docs/dependency-matrix.md` and `docs/dependency-policy.md` documenting current vs target versions, guardrails, and the no-mixed-major policy. 
- Updated backend `spring-app/pom.xml` to import the Spring Boot BOM (`org.springframework.boot:spring-boot-dependencies` at `2.7.18`) and replaced the MySQL artifact with `com.mysql:mysql-connector-j`. 
- Aligned `angular-client` core package majors to Angular 8 and added a lightweight `react-client` scaffold (`package.json`, `src/main.jsx`, `index.html`, README) as the new frontend migration workspace. 
- Added Dependabot configuration (`.github/dependabot.yml`) with grouped update rules and an Angular freeze/ignore policy, a CI workflow (`.github/workflows/dependency-governance.yml`) that runs framework-major checks plus backend/frontend SCA steps, and a tooling script `tools/check-framework-majors.mjs` to enforce core-family major alignment. 

### Testing

- Ran `node tools/check-framework-majors.mjs` which returned OK for Angular and React core family alignment. 
- Attempted `cd spring-app && ./mvnw -q -DskipTests validate` which failed in this environment due to network connectivity preventing the Maven wrapper from downloading the distribution (network error).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea36464b0c832a8c5d4555024bc007)