### PR TITLE
Migrate Resource/Team dates to java.time.LocalDate and add legacy DB migration

### DIFF
--- a/spring-app/src/main/java/com/burt/resourcemanagement/config/LegacyDateMigrationRunner.java
+++ b/spring-app/src/main/java/com/burt/resourcemanagement/config/LegacyDateMigrationRunner.java
@@ -1,0 +1,67 @@
+package com.burt.resourcemanagement.config;
+
+import java.util.Arrays;
+import java.util.List;
+
+import javax.sql.DataSource;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LegacyDateMigrationRunner implements CommandLineRunner {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LegacyDateMigrationRunner.class);
+
+    private final JdbcTemplate jdbcTemplate;
+    private final DataSource dataSource;
+
+    public LegacyDateMigrationRunner(JdbcTemplate jdbcTemplate, DataSource dataSource) {
+        this.jdbcTemplate = jdbcTemplate;
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public void run(String... args) {
+        migrateTable("resources", Arrays.asList("start", "end"));
+        migrateTable("teams", Arrays.asList("start", "end"));
+    }
+
+    private void migrateTable(String tableName, List<String> dateColumns) {
+        try {
+            String dbName;
+            try (java.sql.Connection connection = dataSource.getConnection()) {
+                dbName = connection.getCatalog();
+            }
+            String sqlType = jdbcTemplate.queryForObject(
+                "SELECT DATA_TYPE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ? AND COLUMN_NAME = ?",
+                String.class,
+                dbName,
+                tableName,
+                dateColumns.get(0)
+            );
+
+            if (sqlType == null || !("datetime".equalsIgnoreCase(sqlType) || "timestamp".equalsIgnoreCase(sqlType))) {
+                return;
+            }
+
+            String dateShiftSql = "UPDATE " + tableName
+                + " SET " + dateColumns.get(0) + " = DATE_SUB(" + dateColumns.get(0) + ", INTERVAL 6 HOUR), "
+                + dateColumns.get(1) + " = DATE_SUB(" + dateColumns.get(1) + ", INTERVAL 6 HOUR)"
+                + " WHERE HOUR(" + dateColumns.get(0) + ") = 6 OR HOUR(" + dateColumns.get(1) + ") = 6";
+            jdbcTemplate.execute(dateShiftSql);
+
+            String alterSql = "ALTER TABLE " + tableName
+                + " MODIFY " + dateColumns.get(0) + " DATE NOT NULL,"
+                + " MODIFY " + dateColumns.get(1) + " DATE NOT NULL";
+            jdbcTemplate.execute(alterSql);
+
+            LOGGER.info("Migrated legacy shifted datetime columns on table '{}'.", tableName);
+        } catch (Exception ex) {
+            LOGGER.warn("Skipped date migration for table '{}' due to: {}", tableName, ex.getMessage());
+        }
+    }
+}

--- a/spring-app/src/main/java/com/burt/resourcemanagement/controller/ResourceController.java
+++ b/spring-app/src/main/java/com/burt/resourcemanagement/controller/ResourceController.java
@@ -53,7 +53,6 @@ public class ResourceController {
     @CrossOrigin(origins = "http://localhost:4200")
     @PostMapping("/resources")
     public Resource createResource(@Valid @RequestBody Resource resource) {
-    	resource.fixDate();
         return resourceRepository.save(resource);
     }
 
@@ -70,7 +69,6 @@ public class ResourceController {
         resource.setSudorole(resourceDetails.getSudorole());
         resource.setProject(resourceDetails.getProject());
         resource.setStatus(resourceDetails.getStatus());
-        resource.fixDate();
 
         
         final Resource updatedResource = resourceRepository.save(resource);

--- a/spring-app/src/main/java/com/burt/resourcemanagement/controller/TeamController.java
+++ b/spring-app/src/main/java/com/burt/resourcemanagement/controller/TeamController.java
@@ -37,7 +37,6 @@ public class TeamController {
     @CrossOrigin(origins = "http://localhost:4200")
     @PostMapping("/teams")
     public Team createTeam(@Valid @RequestBody Team team) {
-    	team.fixDate();
         return teamRepository.save(team);
     }
 
@@ -54,7 +53,6 @@ public class TeamController {
         team.setStart(teamDetails.getStart());
         team.setEnd(teamDetails.getEnd());
         team.setProject(teamDetails.getProject());
-        team.fixDate();
         
         final Team updatedTeam = teamRepository.save(team);
         return ResponseEntity.ok(updatedTeam);

--- a/spring-app/src/main/java/com/burt/resourcemanagement/model/Resource.java
+++ b/spring-app/src/main/java/com/burt/resourcemanagement/model/Resource.java
@@ -1,6 +1,6 @@
 package com.burt.resourcemanagement.model;
 
-import java.util.Date;
+import java.time.LocalDate;
 
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -14,113 +14,105 @@ import javax.validation.constraints.Size;
 @Table(name = "resources")
 public class Resource {
 
-	@Id
-	@GeneratedValue(strategy = GenerationType.AUTO)
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
     private long id;
-	
-	@NotNull
-	@Size(min=2, max=64, message="role should be between 2 and 64 characters")
-	private String role;
-	
-	@NotNull
-	private Date start;
-	
-	@NotNull
-	private Date end;
-	
-	@NotNull
-	@Size(min=2, max=64, message="sudorole should be between 2 and 64 characters")
-	private String sudorole;
-	
-	@NotNull
-	@Size(min=2, max=64, message="project should be between 2 and 64 characters")
-	private String project;
-	
-	@NotNull
-	@Size(min=2, max=64, message="status should be between 2 and 64 characters")
-	private String status;
- 
+
+    @NotNull
+    @Size(min = 2, max = 64, message = "role should be between 2 and 64 characters")
+    private String role;
+
+    @NotNull
+    private LocalDate start;
+
+    @NotNull
+    private LocalDate end;
+
+    @NotNull
+    @Size(min = 2, max = 64, message = "sudorole should be between 2 and 64 characters")
+    private String sudorole;
+
+    @NotNull
+    @Size(min = 2, max = 64, message = "project should be between 2 and 64 characters")
+    private String project;
+
+    @NotNull
+    @Size(min = 2, max = 64, message = "status should be between 2 and 64 characters")
+    private String status;
+
     public Resource() {
-  
-    }
-    
-    public void fixDate() {
-    	final long HOUR = 3600*1000;
-    	start = new Date(start.getTime() + 6*HOUR);
-    	end = new Date(end.getTime() + 6*HOUR);
     }
 
-	public Resource(long id, String role, Date start, Date end, String sudorole, String project, String status) {
-		super();
-		this.id = id;
-		this.role = role;
-		this.start = start;
-		this.end = end;
-		this.sudorole = sudorole;
-		this.project = project;
-		this.status = status;
-	}
+    public Resource(long id, String role, LocalDate start, LocalDate end, String sudorole, String project, String status) {
+        super();
+        this.id = id;
+        this.role = role;
+        this.start = start;
+        this.end = end;
+        this.sudorole = sudorole;
+        this.project = project;
+        this.status = status;
+    }
 
-	public long getId() {
-		return id;
-	}
+    public long getId() {
+        return id;
+    }
 
-	public void setId(long id) {
-		this.id = id;
-	}
+    public void setId(long id) {
+        this.id = id;
+    }
 
-	public String getRole() {
-		return role;
-	}
+    public String getRole() {
+        return role;
+    }
 
-	public void setRole(String role) {
-		this.role = role;
-	}
+    public void setRole(String role) {
+        this.role = role;
+    }
 
-	public Date getStart() {
-		return start;
-	}
+    public LocalDate getStart() {
+        return start;
+    }
 
-	public void setStart(Date start) {
-		this.start = start;
-	}
+    public void setStart(LocalDate start) {
+        this.start = start;
+    }
 
-	public Date getEnd() {
-		return end;
-	}
+    public LocalDate getEnd() {
+        return end;
+    }
 
-	public void setEnd(Date end) {
-		this.end = end;
-	}
+    public void setEnd(LocalDate end) {
+        this.end = end;
+    }
 
-	public String getSudorole() {
-		return sudorole;
-	}
+    public String getSudorole() {
+        return sudorole;
+    }
 
-	public void setSudorole(String sudorole) {
-		this.sudorole = sudorole;
-	}
+    public void setSudorole(String sudorole) {
+        this.sudorole = sudorole;
+    }
 
-	public String getProject() {
-		return project;
-	}
+    public String getProject() {
+        return project;
+    }
 
-	public void setProject(String project) {
-		this.project = project;
-	}
+    public void setProject(String project) {
+        this.project = project;
+    }
 
-	public String getStatus() {
-		return status;
-	}
+    public String getStatus() {
+        return status;
+    }
 
-	public void setStatus(String status) {
-		this.status = status;
-	}
+    public void setStatus(String status) {
+        this.status = status;
+    }
 
-	@Override
-	public String toString() {
-		return "Resource [id=" + id + ", role=" + role + ", start=" + start + ", end=" + end + ", sudorole=" + sudorole
-				+ ", project=" + project + ", status=" + status + "]";
-	}
-
+    @Override
+    public String toString() {
+        return "Resource [id=" + id + ", role=" + role + ", start=" + start + ", end=" + end + ", sudorole=" + sudorole
+                + ", project=" + project + ", status=" + status + "]";
+    }
 }

--- a/spring-app/src/main/java/com/burt/resourcemanagement/model/Team.java
+++ b/spring-app/src/main/java/com/burt/resourcemanagement/model/Team.java
@@ -1,6 +1,6 @@
 package com.burt.resourcemanagement.model;
 
-import java.util.Date;
+import java.time.LocalDate;
 import java.util.List;
 
 import javax.persistence.ElementCollection;
@@ -15,114 +15,107 @@ import javax.validation.constraints.Size;
 @Entity
 @Table(name = "teams")
 public class Team {
-	
-	@Id
-	@GeneratedValue(strategy = GenerationType.AUTO)
-	private long id;
-	
-	@NotNull
-	@Size(min=2, max=64, message="name should be between 2 and 64 characters")
-	private String name;
-	
-	@NotNull
-	@ElementCollection
-	private List<String> resources;
-	
-	@NotNull
-	@Size(min=2, max=64, message="status should be between 2 and 64 characters")
-	private String status;
-	
-	@NotNull
-	private Date start;
-	
-	@NotNull
-	private Date end;
-	
-	@NotNull
-	@Size(min=2, max=64, message="project should be between 2 and 64 characters")
-	private String project;
-	
-	public Team() {
-		
-	}
 
-	public Team(long id, String name, List<String> resources, String status, Date start, Date end, String project) {
-		super();
-		this.id = id;
-		this.name = name;
-		this.resources = resources;
-		this.status = status;
-		this.start = start;
-		this.end = end;
-		this.project = project;
-	}
-	
-	public void fixDate() {
-    	final long HOUR = 3600*1000;
-    	start = new Date(start.getTime() + 6*HOUR);
-    	end = new Date(end.getTime() + 6*HOUR);
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private long id;
+
+    @NotNull
+    @Size(min = 2, max = 64, message = "name should be between 2 and 64 characters")
+    private String name;
+
+    @NotNull
+    @ElementCollection
+    private List<String> resources;
+
+    @NotNull
+    @Size(min = 2, max = 64, message = "status should be between 2 and 64 characters")
+    private String status;
+
+    @NotNull
+    private LocalDate start;
+
+    @NotNull
+    private LocalDate end;
+
+    @NotNull
+    @Size(min = 2, max = 64, message = "project should be between 2 and 64 characters")
+    private String project;
+
+    public Team() {
+
     }
 
-	public long getId() {
-		return id;
-	}
+    public Team(long id, String name, List<String> resources, String status, LocalDate start, LocalDate end, String project) {
+        super();
+        this.id = id;
+        this.name = name;
+        this.resources = resources;
+        this.status = status;
+        this.start = start;
+        this.end = end;
+        this.project = project;
+    }
 
-	public void setId(long id) {
-		this.id = id;
-	}
+    public long getId() {
+        return id;
+    }
 
-	public String getName() {
-		return name;
-	}
+    public void setId(long id) {
+        this.id = id;
+    }
 
-	public void setName(String name) {
-		this.name = name;
-	}
+    public String getName() {
+        return name;
+    }
 
-	public List<String> getResources() {
-		return resources;
-	}
+    public void setName(String name) {
+        this.name = name;
+    }
 
-	public void setResources(List<String> resources) {
-		this.resources = resources;
-	}
+    public List<String> getResources() {
+        return resources;
+    }
 
-	public String getStatus() {
-		return status;
-	}
+    public void setResources(List<String> resources) {
+        this.resources = resources;
+    }
 
-	public void setStatus(String status) {
-		this.status = status;
-	}
+    public String getStatus() {
+        return status;
+    }
 
-	public Date getStart() {
-		return start;
-	}
+    public void setStatus(String status) {
+        this.status = status;
+    }
 
-	public void setStart(Date start) {
-		this.start = start;
-	}
+    public LocalDate getStart() {
+        return start;
+    }
 
-	public Date getEnd() {
-		return end;
-	}
+    public void setStart(LocalDate start) {
+        this.start = start;
+    }
 
-	public void setEnd(Date end) {
-		this.end = end;
-	}
+    public LocalDate getEnd() {
+        return end;
+    }
 
-	public String getProject() {
-		return project;
-	}
+    public void setEnd(LocalDate end) {
+        this.end = end;
+    }
 
-	public void setProject(String project) {
-		this.project = project;
-	}
+    public String getProject() {
+        return project;
+    }
 
-	@Override
-	public String toString() {
-		return "Team [id=" + id + ", name=" + name + ", resources=" + resources + ", status=" + status + ", start="
-				+ start + ", end=" + end + ", project=" + project + "]";
-	}
+    public void setProject(String project) {
+        this.project = project;
+    }
 
+    @Override
+    public String toString() {
+        return "Team [id=" + id + ", name=" + name + ", resources=" + resources + ", status=" + status + ", start="
+                + start + ", end=" + end + ", project=" + project + "]";
+    }
 }

--- a/spring-app/src/main/resources/application.properties
+++ b/spring-app/src/main/resources/application.properties
@@ -10,3 +10,7 @@ spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.MySQL8Dialect
 
 # Hibernate ddl auto (create, create-drop, validate, update)
 spring.jpa.hibernate.ddl-auto = create-drop
+
+# Jackson Java Time serialization/deserialization settings
+spring.jackson.serialization.write-dates-as-timestamps=false
+spring.jackson.time-zone=UTC

--- a/spring-app/src/test/java/com/burt/resourcemanagement/JavaTimeSerializationTest.java
+++ b/spring-app/src/test/java/com/burt/resourcemanagement/JavaTimeSerializationTest.java
@@ -1,0 +1,63 @@
+package com.burt.resourcemanagement;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.TimeZone;
+
+import com.burt.resourcemanagement.model.Resource;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+import org.junit.Test;
+
+public class JavaTimeSerializationTest {
+
+    @Test
+    public void resourceDatesSerializeAsIsoDateStrings() throws Exception {
+        ObjectMapper objectMapper = new ObjectMapper()
+            .registerModule(new JavaTimeModule())
+            .disable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        Resource resource = new Resource(
+            10L,
+            "Engineer",
+            LocalDate.of(2026, 3, 31),
+            LocalDate.of(2026, 4, 30),
+            "Admin",
+            "Apollo",
+            "Active"
+        );
+
+        String json = objectMapper.writeValueAsString(resource);
+
+        assertTrue(json.contains("\"start\":\"2026-03-31\""));
+        assertTrue(json.contains("\"end\":\"2026-04-30\""));
+    }
+
+    @Test
+    public void resourceDatesDeserializeWithoutTimezoneShiftAtBoundary() throws Exception {
+        ObjectMapper objectMapper = new ObjectMapper()
+            .registerModule(new JavaTimeModule())
+            .disable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        TimeZone originalTz = TimeZone.getDefault();
+        try {
+            TimeZone.setDefault(TimeZone.getTimeZone(ZoneId.of("America/Los_Angeles")));
+
+            String json = "{\"id\":10,\"role\":\"Engineer\",\"start\":\"2026-03-08\",\"end\":\"2026-03-09\",\"sudorole\":\"Admin\",\"project\":\"Apollo\",\"status\":\"Active\"}";
+            Resource parsed = objectMapper.readValue(json, Resource.class);
+
+            assertEquals(LocalDate.of(2026, 3, 8), parsed.getStart());
+            assertEquals(LocalDate.of(2026, 3, 9), parsed.getEnd());
+        } finally {
+            TimeZone.setDefault(originalTz);
+        }
+    }
+}

--- a/spring-app/src/test/java/com/burt/resourcemanagement/LegacyDateMigrationRunnerTest.java
+++ b/spring-app/src/test/java/com/burt/resourcemanagement/LegacyDateMigrationRunnerTest.java
@@ -1,0 +1,65 @@
+package com.burt.resourcemanagement;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.Connection;
+
+import javax.sql.DataSource;
+
+import com.burt.resourcemanagement.config.LegacyDateMigrationRunner;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LegacyDateMigrationRunnerTest {
+
+    @Mock
+    private JdbcTemplate jdbcTemplate;
+
+    @Mock
+    private DataSource dataSource;
+
+    @Mock
+    private Connection connection;
+
+    @Test
+    public void migratesLegacyDatetimeColumns() throws Exception {
+        when(dataSource.getConnection()).thenReturn(connection);
+        when(connection.getCatalog()).thenReturn("resource_db");
+        when(jdbcTemplate.queryForObject(anyString(), eq(String.class), eq("resource_db"), eq("resources"), eq("start")))
+            .thenReturn("datetime");
+        when(jdbcTemplate.queryForObject(anyString(), eq(String.class), eq("resource_db"), eq("teams"), eq("start")))
+            .thenReturn("timestamp");
+
+        LegacyDateMigrationRunner runner = new LegacyDateMigrationRunner(jdbcTemplate, dataSource);
+        runner.run();
+
+        verify(jdbcTemplate).execute("UPDATE resources SET start = DATE_SUB(start, INTERVAL 6 HOUR), end = DATE_SUB(end, INTERVAL 6 HOUR) WHERE HOUR(start) = 6 OR HOUR(end) = 6");
+        verify(jdbcTemplate).execute("ALTER TABLE resources MODIFY start DATE NOT NULL, MODIFY end DATE NOT NULL");
+        verify(jdbcTemplate).execute("UPDATE teams SET start = DATE_SUB(start, INTERVAL 6 HOUR), end = DATE_SUB(end, INTERVAL 6 HOUR) WHERE HOUR(start) = 6 OR HOUR(end) = 6");
+        verify(jdbcTemplate).execute("ALTER TABLE teams MODIFY start DATE NOT NULL, MODIFY end DATE NOT NULL");
+    }
+
+    @Test
+    public void skipsWhenColumnsAlreadyDate() throws Exception {
+        when(dataSource.getConnection()).thenReturn(connection);
+        when(connection.getCatalog()).thenReturn("resource_db");
+        when(jdbcTemplate.queryForObject(anyString(), eq(String.class), eq("resource_db"), eq("resources"), eq("start")))
+            .thenReturn("date");
+        when(jdbcTemplate.queryForObject(anyString(), eq(String.class), eq("resource_db"), eq("teams"), eq("start")))
+            .thenReturn("date");
+
+        LegacyDateMigrationRunner runner = new LegacyDateMigrationRunner(jdbcTemplate, dataSource);
+        runner.run();
+
+        verify(jdbcTemplate, never()).execute(anyString());
+    }
+}


### PR DESCRIPTION
### Motivation
- Remove ad-hoc `fixDate()` timezone shifting and stop mutating incoming dates in controllers to avoid DST/timezone bugs.
- Use the `java.time` API for clearer date semantics (date-only vs timestamp) and to make JSON serialization/deserialization predictable.
- Provide a migration path so existing databases with previously shifted `DATETIME`/`TIMESTAMP` values are corrected when the model moves to `DATE` columns.

### Description
- Replaced `java.util.Date` with `java.time.LocalDate` in `Resource` and `Team` and removed the `fixDate()` methods from both model classes.
- Removed calls to `fixDate()` in `ResourceController` and `TeamController` so create/update flows persist submitted `LocalDate` values directly.
- Added Jackson Java Time settings in `application.properties` (`spring.jackson.serialization.write-dates-as-timestamps=false` and `spring.jackson.time-zone=UTC`) and tests register `JavaTimeModule` to ensure ISO date strings and stable timezone behavior.
- Added `LegacyDateMigrationRunner` (a `CommandLineRunner`) that detects legacy `DATETIME`/`TIMESTAMP` columns for `resources` and `teams`, runs SQL to subtract the historical `+6` hour shift for affected rows, and alters the columns to `DATE`.

### Testing
- Added automated tests `JavaTimeSerializationTest` (serialization/deserialization and DST boundary safety) and `LegacyDateMigrationRunnerTest` (migration and no-op scenarios).
- Attempted `./mvnw -Dtest=JavaTimeSerializationTest,LegacyDateMigrationRunnerTest test` which failed in this environment due to the Maven wrapper download failing because of a network error.
- Ran `mvn -Dtest=JavaTimeSerializationTest,LegacyDateMigrationRunnerTest test` which completed successfully with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea36482338832ab3010b7d35dc85af)