### PR TITLE
Normalize resource/team GET endpoints and add API contract + tests

### DIFF
--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -1,0 +1,83 @@
+# API Contract (React Integration)
+
+Base URL: `/api/v1`
+
+## Resources
+
+### GET `/resources`
+Returns a filtered list of resources.
+
+Supported query params:
+- `role` (optional): case-insensitive contains match against `role`
+- `project` (optional): case-insensitive contains match against `project`
+- `status` (optional): case-insensitive contains match against `status`
+- `term` (optional): case-insensitive contains match against `role`, `project`, or `sudorole`
+
+Response:
+- `200 OK` with JSON array of `Resource`
+
+### GET `/resources/{id}`
+Returns one resource by numeric id.
+
+Response:
+- `200 OK` with `Resource`
+- `404 Not Found` when id does not exist
+
+### GET `/resources/search?term=...`
+Dedicated free-text search endpoint.
+
+Response:
+- `200 OK` with JSON array of matching `Resource`
+
+### Deprecated (temporary compatibility)
+#### GET `/resources/{role}`
+Legacy path-based search endpoint retained temporarily.
+
+Deprecation response headers:
+- `Deprecation: true`
+- `Sunset: Wed, 31 Dec 2026 23:59:59 GMT`
+- `Link: </docs/api-contract.md>; rel="deprecation"`
+
+## Teams
+
+### GET `/teams`
+Returns a filtered list of teams.
+
+Supported query params:
+- `name` (optional): case-insensitive contains match against `name`
+- `project` (optional): case-insensitive contains match against `project`
+- `status` (optional): case-insensitive contains match against `status`
+- `term` (optional): case-insensitive contains match against `name` or `project`
+
+Response:
+- `200 OK` with JSON array of `Team`
+
+### GET `/teams/{id}`
+Returns one team by numeric id.
+
+Response:
+- `200 OK` with `Team`
+- `404 Not Found` when id does not exist
+
+### GET `/teams/search?term=...`
+Dedicated free-text search endpoint.
+
+Response:
+- `200 OK` with JSON array of matching `Team`
+
+### Deprecated (temporary compatibility)
+#### GET `/teams/{name}`
+Legacy path-based search endpoint retained temporarily.
+
+Deprecation response headers:
+- `Deprecation: true`
+- `Sunset: Wed, 31 Dec 2026 23:59:59 GMT`
+- `Link: </docs/api-contract.md>; rel="deprecation"`
+
+## Existing write endpoints (unchanged)
+- `POST /resources`
+- `PUT /resources/edit/{id}`
+- `DELETE /resources/{id}`
+- `POST /teams`
+- `PUT /teams/edit/{id}`
+- `DELETE /teams/{id}`

--- a/spring-app/src/main/java/com/burt/resourcemanagement/controller/ResourceController.java
+++ b/spring-app/src/main/java/com/burt/resourcemanagement/controller/ResourceController.java
@@ -1,13 +1,14 @@
 package com.burt.resourcemanagement.controller;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import javax.validation.Valid;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.burt.resourcemanagement.exception.ResourceNotFoundException;
@@ -31,38 +33,66 @@ public class ResourceController {
 
     @CrossOrigin(origins = "http://localhost:4200")
     @GetMapping("/resources")
-    public List<Resource> getAllResources() {
-        return resourceRepository.findAll();
+    public List<Resource> getAllResources(
+        @RequestParam(value = "role", required = false) String role,
+        @RequestParam(value = "project", required = false) String project,
+        @RequestParam(value = "status", required = false) String status,
+        @RequestParam(value = "term", required = false) String term) {
+        return resourceRepository.findAll().stream()
+            .filter(resource -> containsIgnoreCase(resource.getRole(), role))
+            .filter(resource -> containsIgnoreCase(resource.getProject(), project))
+            .filter(resource -> containsIgnoreCase(resource.getStatus(), status))
+            .filter(resource -> containsIgnoreCase(resource.getRole(), term)
+                || containsIgnoreCase(resource.getProject(), term)
+                || containsIgnoreCase(resource.getSudorole(), term))
+            .collect(Collectors.toList());
     }
 
     @CrossOrigin(origins = "http://localhost:4200")
-    @GetMapping("/resources/{role}")
-    public List<Resource> getResourceByRole(@PathVariable(value = "role") String role)
-        throws ResourceNotFoundException {
-    	//System.out.println("search is being called " + role);
-    	List<Resource> allResources = resourceRepository.findAll();
-    	List<Resource> results = new ArrayList<Resource>();
-    	for(Resource resource : allResources) {
-    		if(resource.getRole().contains(role) || resource.getProject().contains(role)) {
-    			results.add(resource);
-    		}
-    	}
-        return results;
+    @GetMapping("/resources/search")
+    public List<Resource> searchResources(@RequestParam(value = "term") String term) {
+        return resourceRepository.findAll().stream()
+            .filter(resource -> containsIgnoreCase(resource.getRole(), term)
+                || containsIgnoreCase(resource.getProject(), term)
+                || containsIgnoreCase(resource.getSudorole(), term))
+            .collect(Collectors.toList());
     }
-    
+
+    @CrossOrigin(origins = "http://localhost:4200")
+    @GetMapping("/resources/{id:\\d+}")
+    public ResponseEntity<Resource> getResourceById(@PathVariable(value = "id") Long resourceId)
+        throws ResourceNotFoundException {
+        Resource resource = resourceRepository.findById(resourceId)
+            .orElseThrow(() -> new ResourceNotFoundException("Resource not found for this id: " + resourceId));
+        return ResponseEntity.ok(resource);
+    }
+
+    @Deprecated
+    @CrossOrigin(origins = "http://localhost:4200")
+    @GetMapping("/resources/{role:[^\\d].*}")
+    public ResponseEntity<List<Resource>> getResourceByRoleDeprecated(@PathVariable(value = "role") String role) {
+        List<Resource> results = resourceRepository.findAll().stream()
+            .filter(resource -> containsIgnoreCase(resource.getRole(), role)
+                || containsIgnoreCase(resource.getProject(), role))
+            .collect(Collectors.toList());
+
+        HttpHeaders headers = deprecationHeaders();
+        return ResponseEntity.ok().headers(headers).body(results);
+    }
+
     @CrossOrigin(origins = "http://localhost:4200")
     @PostMapping("/resources")
     public Resource createResource(@Valid @RequestBody Resource resource) {
-    	resource.fixDate();
+        resource.fixDate();
         return resourceRepository.save(resource);
     }
 
     @CrossOrigin(origins = "http://localhost:4200")
     @PutMapping("/resources/edit/{id}")
     public ResponseEntity<Resource> updateResource(@PathVariable(value = "id") Long resourceId,
-         @Valid @RequestBody Resource resourceDetails) throws ResourceNotFoundException {
+        @Valid @RequestBody Resource resourceDetails) throws ResourceNotFoundException {
         Resource resource = resourceRepository.findById(resourceId)
-        .orElseThrow(() -> new ResourceNotFoundException("Resource not found for this id: " + resourceId));
+            .orElseThrow(() -> new ResourceNotFoundException("Resource not found for this id: " + resourceId));
 
         resource.setRole(resourceDetails.getRole());
         resource.setStart(resourceDetails.getStart());
@@ -72,7 +102,6 @@ public class ResourceController {
         resource.setStatus(resourceDetails.getStatus());
         resource.fixDate();
 
-        
         final Resource updatedResource = resourceRepository.save(resource);
         return ResponseEntity.ok(updatedResource);
     }
@@ -80,13 +109,25 @@ public class ResourceController {
     @CrossOrigin(origins = "http://localhost:4200")
     @DeleteMapping("/resources/{id}")
     public Map<String, Boolean> deleteResource(@PathVariable(value = "id") Long resourceId)
-         throws ResourceNotFoundException {
+        throws ResourceNotFoundException {
         Resource resource = resourceRepository.findById(resourceId)
-       .orElseThrow(() -> new ResourceNotFoundException("Resource not found for this id: " + resourceId));
+            .orElseThrow(() -> new ResourceNotFoundException("Resource not found for this id: " + resourceId));
 
         resourceRepository.delete(resource);
         Map<String, Boolean> response = new HashMap<>();
         response.put("deleted", Boolean.TRUE);
         return response;
+    }
+
+    private boolean containsIgnoreCase(String fieldValue, String queryValue) {
+        return queryValue == null || (fieldValue != null && fieldValue.toLowerCase().contains(queryValue.toLowerCase()));
+    }
+
+    private HttpHeaders deprecationHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Deprecation", "true");
+        headers.add("Sunset", "Wed, 31 Dec 2026 23:59:59 GMT");
+        headers.add("Link", "</docs/api-contract.md>; rel=\"deprecation\"");
+        return headers;
     }
 }

--- a/spring-app/src/main/java/com/burt/resourcemanagement/controller/TeamController.java
+++ b/spring-app/src/main/java/com/burt/resourcemanagement/controller/TeamController.java
@@ -3,10 +3,12 @@ package com.burt.resourcemanagement.controller;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import javax.validation.Valid;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -16,6 +18,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.burt.resourcemanagement.exception.TeamNotFoundException;
@@ -30,24 +33,65 @@ public class TeamController {
 
     @CrossOrigin(origins = "http://localhost:4200")
     @GetMapping("/teams")
-    public List<Team> getAllTeams() {
-        return teamRepository.findAll();
+    public List<Team> getAllTeams(
+        @RequestParam(value = "name", required = false) String name,
+        @RequestParam(value = "project", required = false) String project,
+        @RequestParam(value = "status", required = false) String status,
+        @RequestParam(value = "term", required = false) String term) {
+        return teamRepository.findAll().stream()
+            .filter(team -> containsIgnoreCase(team.getName(), name))
+            .filter(team -> containsIgnoreCase(team.getProject(), project))
+            .filter(team -> containsIgnoreCase(team.getStatus(), status))
+            .filter(team -> containsIgnoreCase(team.getName(), term)
+                || containsIgnoreCase(team.getProject(), term))
+            .collect(Collectors.toList());
     }
-    
+
+    @CrossOrigin(origins = "http://localhost:4200")
+    @GetMapping("/teams/search")
+    public List<Team> searchTeams(@RequestParam(value = "term") String term) {
+        return teamRepository.findAll().stream()
+            .filter(team -> containsIgnoreCase(team.getName(), term)
+                || containsIgnoreCase(team.getProject(), term))
+            .collect(Collectors.toList());
+    }
+
+    @CrossOrigin(origins = "http://localhost:4200")
+    @GetMapping("/teams/{id:\\d+}")
+    public ResponseEntity<Team> getTeamById(@PathVariable(value = "id") Long teamId)
+        throws TeamNotFoundException {
+        Team team = teamRepository.findById(teamId)
+            .orElseThrow(() -> new TeamNotFoundException("Team not found for this id :: " + teamId));
+        return ResponseEntity.ok(team);
+    }
+
+    @Deprecated
+    @CrossOrigin(origins = "http://localhost:4200")
+    @GetMapping("/teams/{name:[^\\d].*}")
+    public ResponseEntity<List<Team>> getTeamByNameDeprecated(@PathVariable(value = "name") String name) {
+        List<Team> results = teamRepository.findAll().stream()
+            .filter(team -> containsIgnoreCase(team.getName(), name)
+                || containsIgnoreCase(team.getProject(), name))
+            .collect(Collectors.toList());
+
+        HttpHeaders headers = deprecationHeaders();
+        return ResponseEntity.ok().headers(headers).body(results);
+    }
+
     @CrossOrigin(origins = "http://localhost:4200")
     @PostMapping("/teams")
     public Team createTeam(@Valid @RequestBody Team team) {
-    	team.fixDate();
+        team.fixDate();
         return teamRepository.save(team);
     }
 
     @CrossOrigin(origins = "http://localhost:4200")
     @PutMapping("/teams/edit/{id}")
     public ResponseEntity<Team> updateTeam(@PathVariable(value = "id") Long teamId,
-         @Valid @RequestBody Team teamDetails) throws TeamNotFoundException {
+        @Valid @RequestBody Team teamDetails) throws TeamNotFoundException {
         Team team = teamRepository.findById(teamId)
-        .orElseThrow(() -> new TeamNotFoundException("Team not found for this id :: " + teamId));
-        
+            .orElseThrow(() -> new TeamNotFoundException("Team not found for this id :: " + teamId));
+
         team.setName(teamDetails.getName());
         team.setResources(teamDetails.getResources());
         team.setStatus(teamDetails.getStatus());
@@ -55,7 +99,7 @@ public class TeamController {
         team.setEnd(teamDetails.getEnd());
         team.setProject(teamDetails.getProject());
         team.fixDate();
-        
+
         final Team updatedTeam = teamRepository.save(team);
         return ResponseEntity.ok(updatedTeam);
     }
@@ -63,13 +107,25 @@ public class TeamController {
     @CrossOrigin(origins = "http://localhost:4200")
     @DeleteMapping("/teams/{id}")
     public Map<String, Boolean> deleteTeam(@PathVariable(value = "id") Long teamId)
-         throws TeamNotFoundException {
+        throws TeamNotFoundException {
         Team team = teamRepository.findById(teamId)
-       .orElseThrow(() -> new TeamNotFoundException("Team not found for this id :: " + teamId));
+            .orElseThrow(() -> new TeamNotFoundException("Team not found for this id :: " + teamId));
 
         teamRepository.delete(team);
         Map<String, Boolean> response = new HashMap<>();
         response.put("deleted", Boolean.TRUE);
         return response;
+    }
+
+    private boolean containsIgnoreCase(String fieldValue, String queryValue) {
+        return queryValue == null || (fieldValue != null && fieldValue.toLowerCase().contains(queryValue.toLowerCase()));
+    }
+
+    private HttpHeaders deprecationHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Deprecation", "true");
+        headers.add("Sunset", "Wed, 31 Dec 2026 23:59:59 GMT");
+        headers.add("Link", "</docs/api-contract.md>; rel=\"deprecation\"");
+        return headers;
     }
 }

--- a/spring-app/src/test/java/com/burt/resourcemanagement/controller/ResourceControllerHttpTest.java
+++ b/spring-app/src/test/java/com/burt/resourcemanagement/controller/ResourceControllerHttpTest.java
@@ -1,0 +1,87 @@
+package com.burt.resourcemanagement.controller;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.Optional;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.burt.resourcemanagement.model.Resource;
+import com.burt.resourcemanagement.repository.ResourceRepository;
+
+@RunWith(SpringRunner.class)
+@WebMvcTest(ResourceController.class)
+public class ResourceControllerHttpTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ResourceRepository resourceRepository;
+
+    @Test
+    public void listResourcesWithFiltersReturnsOk() throws Exception {
+        Resource backend = resource(1L, "Backend Engineer", "Apollo");
+        Resource frontend = resource(2L, "Frontend Engineer", "Hermes");
+        when(resourceRepository.findAll()).thenReturn(Arrays.asList(backend, frontend));
+
+        mockMvc.perform(get("/api/v1/resources").param("role", "Backend").param("project", "Apollo"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$", hasSize(1)))
+            .andExpect(jsonPath("$[0].id").value(1));
+    }
+
+    @Test
+    public void getResourceByIdReturnsOk() throws Exception {
+        Resource backend = resource(7L, "Platform Engineer", "Atlas");
+        when(resourceRepository.findById(7L)).thenReturn(Optional.of(backend));
+
+        mockMvc.perform(get("/api/v1/resources/7"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(7));
+    }
+
+    @Test
+    public void getResourceByIdReturnsNotFound() throws Exception {
+        when(resourceRepository.findById(anyLong())).thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/api/v1/resources/77"))
+            .andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void deprecatedSearchEndpointReturnsDeprecationHeaders() throws Exception {
+        when(resourceRepository.findAll()).thenReturn(Arrays.asList(resource(1L, "Backend Engineer", "Apollo")));
+
+        mockMvc.perform(get("/api/v1/resources/backend"))
+            .andExpect(status().isOk())
+            .andExpect(header().string("Deprecation", "true"))
+            .andExpect(header().string("Sunset", "Wed, 31 Dec 2026 23:59:59 GMT"));
+    }
+
+    private Resource resource(long id, String role, String project) {
+        Resource resource = new Resource();
+        resource.setId(id);
+        resource.setRole(role);
+        resource.setProject(project);
+        resource.setStatus("Active");
+        resource.setSudorole("Member");
+        resource.setStart(new Date());
+        resource.setEnd(new Date());
+        return resource;
+    }
+}

--- a/spring-app/src/test/java/com/burt/resourcemanagement/controller/TeamControllerHttpTest.java
+++ b/spring-app/src/test/java/com/burt/resourcemanagement/controller/TeamControllerHttpTest.java
@@ -1,0 +1,86 @@
+package com.burt.resourcemanagement.controller;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.Optional;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.burt.resourcemanagement.model.Team;
+import com.burt.resourcemanagement.repository.TeamRepository;
+
+@RunWith(SpringRunner.class)
+@WebMvcTest(TeamController.class)
+public class TeamControllerHttpTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private TeamRepository teamRepository;
+
+    @Test
+    public void listTeamsWithFiltersReturnsOk() throws Exception {
+        Team alpha = team(1L, "Alpha", "Apollo");
+        Team beta = team(2L, "Beta", "Hermes");
+        when(teamRepository.findAll()).thenReturn(Arrays.asList(alpha, beta));
+
+        mockMvc.perform(get("/api/v1/teams").param("name", "Alpha").param("project", "Apollo"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$", hasSize(1)))
+            .andExpect(jsonPath("$[0].id").value(1));
+    }
+
+    @Test
+    public void getTeamByIdReturnsOk() throws Exception {
+        when(teamRepository.findById(8L)).thenReturn(Optional.of(team(8L, "Core", "Atlas")));
+
+        mockMvc.perform(get("/api/v1/teams/8"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(8));
+    }
+
+    @Test
+    public void getTeamByIdReturnsNotFound() throws Exception {
+        when(teamRepository.findById(anyLong())).thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/api/v1/teams/81"))
+            .andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void deprecatedSearchEndpointReturnsDeprecationHeaders() throws Exception {
+        when(teamRepository.findAll()).thenReturn(Arrays.asList(team(3L, "Platform", "Atlas")));
+
+        mockMvc.perform(get("/api/v1/teams/platform"))
+            .andExpect(status().isOk())
+            .andExpect(header().string("Deprecation", "true"))
+            .andExpect(header().string("Sunset", "Wed, 31 Dec 2026 23:59:59 GMT"));
+    }
+
+    private Team team(long id, String name, String project) {
+        Team team = new Team();
+        team.setId(id);
+        team.setName(name);
+        team.setProject(project);
+        team.setStatus("Active");
+        team.setResources(Arrays.asList("r1", "r2"));
+        team.setStart(new Date());
+        team.setEnd(new Date());
+        return team;
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide explicit, predictable read endpoints for resources and teams so frontends can use query parameters and numeric IDs reliably.
- Preserve backward compatibility for existing path-based searches while clearly marking them deprecated to give consumers time to migrate.
- Lock expected HTTP behavior with controller-level tests to avoid regressions in status codes and deprecation headers.

### Description
- Reworked resource endpoints to expose `GET /api/v1/resources` with query filters (`role`, `project`, `status`, `term`), `GET /api/v1/resources/{id}` for numeric IDs, and `GET /api/v1/resources/search?term=...`, and added a deprecated path-based `GET /api/v1/resources/{role}` that returns deprecation headers (`Deprecation`, `Sunset`, `Link`).
- Mirrored the same normalization for teams with `GET /api/v1/teams` (filters: `name`, `project`, `status`, `term`), `GET /api/v1/teams/{id}`, `GET /api/v1/teams/search?term=...`, and a deprecated `GET /api/v1/teams/{name}` that emits deprecation headers.
- Added shared case-insensitive contains filtering helper and deprecation header helper to both controllers.
- Published `docs/api-contract.md` documenting the new API shapes and deprecation contract, and added MockMvc controller tests `ResourceControllerHttpTest` and `TeamControllerHttpTest` to verify list/filter behavior, get-by-id success and 404, and deprecation headers.

### Testing
- Ran the wrapper attempt `./mvnw -q -Dtest=ResourceControllerHttpTest,TeamControllerHttpTest test`, which failed to download the wrapper distribution due to network restrictions in the environment.
- Ran `mvn -q -Dtest=ResourceControllerHttpTest,TeamControllerHttpTest test` with the installed Maven and the two controller test classes, and the tests executed successfully.
- The repository now contains the new tests and `docs/api-contract.md` to support React integration and future automated checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea3649cd48832aadb10221451f94a1)