### PR TITLE
Remove hardcoded credentials; centralize CORS and move config to env/profile files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,21 @@
+# Spring profile
+SPRING_PROFILES_ACTIVE=dev
+SERVER_PORT=4444
+
+# Development database
+DEV_DB_URL=jdbc:mysql://localhost:3306/resource_db?useUnicode=true&useJDBCCompliantTimezoneShift=true&useLegacyDatetimeCode=false&serverTimezone=UTC
+DEV_DB_USERNAME=your_dev_username
+DEV_DB_PASSWORD=your_dev_password
+DEV_CORS_ALLOWED_ORIGINS=http://localhost:4200
+
+# Production database
+PROD_DB_URL=jdbc:mysql://db-host:3306/resource_db
+PROD_DB_USERNAME=your_prod_username
+PROD_DB_PASSWORD=your_prod_password
+PROD_HIBERNATE_DDL_AUTO=validate
+PROD_CORS_ALLOWED_ORIGINS=https://your-production-client.example.com
+
+# Database integration test
+TEST_DB_URL=jdbc:mysql://localhost:3306/resource_db
+TEST_DB_USERNAME=your_test_username
+TEST_DB_PASSWORD=your_test_password

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,8 @@ testem.log
 .DS_Store
 Thumbs.db
 .vscode/launch.json
+
+# local env files
+.env
+.env.*
+!.env.example

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,48 @@
+# Configuration
+
+This service now reads all sensitive runtime configuration from environment variables (or a local `.env` loaded by your tooling), instead of hardcoding values in source files.
+
+## Files and Profiles
+
+- `spring-app/src/main/resources/application.properties`
+  - Contains only non-secret shared settings and active profile selection.
+- `spring-app/src/main/resources/application-dev.yml`
+  - Development datasource and CORS settings, all sourced from environment variables.
+- `spring-app/src/main/resources/application-prod.yml`
+  - Production datasource and CORS settings, all sourced from environment variables.
+
+## Required Environment Variables
+
+### Development (`SPRING_PROFILES_ACTIVE=dev`)
+
+- `DEV_DB_URL`
+- `DEV_DB_USERNAME`
+- `DEV_DB_PASSWORD`
+- `DEV_CORS_ALLOWED_ORIGINS`
+
+### Production (`SPRING_PROFILES_ACTIVE=prod`)
+
+- `PROD_DB_URL`
+- `PROD_DB_USERNAME`
+- `PROD_DB_PASSWORD`
+- `PROD_HIBERNATE_DDL_AUTO` (optional, defaults to `validate`)
+- `PROD_CORS_ALLOWED_ORIGINS`
+
+### Database test
+
+- `TEST_DB_URL` (optional, defaults to local MySQL URL)
+- `TEST_DB_USERNAME` (optional, defaults to `root`)
+- `TEST_DB_PASSWORD` (optional, defaults to empty)
+
+## CORS
+
+CORS is configured centrally in `WebConfig` and applies to `/api/**`. Set allowed origins through:
+
+- `DEV_CORS_ALLOWED_ORIGINS` for development
+- `PROD_CORS_ALLOWED_ORIGINS` for production
+
+Multiple origins can be supplied as a comma-separated value.
+
+## Secret Rotation and Git History Cleanup
+
+If previously committed credentials were real, rotate them immediately in your database/provider and then rewrite git history to remove leaked secrets from old commits before sharing the repository.

--- a/spring-app/src/main/java/com/burt/resourcemanagement/config/WebConfig.java
+++ b/spring-app/src/main/java/com/burt/resourcemanagement/config/WebConfig.java
@@ -1,0 +1,21 @@
+package com.burt.resourcemanagement.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Value("${app.cors.allowed-origins:http://localhost:4200}")
+    private String[] allowedOrigins;
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/api/**")
+                .allowedOrigins(allowedOrigins)
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedHeaders("*");
+    }
+}

--- a/spring-app/src/main/java/com/burt/resourcemanagement/controller/ResourceController.java
+++ b/spring-app/src/main/java/com/burt/resourcemanagement/controller/ResourceController.java
@@ -9,7 +9,6 @@ import javax.validation.Valid;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -29,13 +28,11 @@ public class ResourceController {
     @Autowired
     private ResourceRepository resourceRepository;
 
-    @CrossOrigin(origins = "http://localhost:4200")
     @GetMapping("/resources")
     public List<Resource> getAllResources() {
         return resourceRepository.findAll();
     }
 
-    @CrossOrigin(origins = "http://localhost:4200")
     @GetMapping("/resources/{role}")
     public List<Resource> getResourceByRole(@PathVariable(value = "role") String role)
         throws ResourceNotFoundException {
@@ -50,14 +47,12 @@ public class ResourceController {
         return results;
     }
     
-    @CrossOrigin(origins = "http://localhost:4200")
     @PostMapping("/resources")
     public Resource createResource(@Valid @RequestBody Resource resource) {
     	resource.fixDate();
         return resourceRepository.save(resource);
     }
 
-    @CrossOrigin(origins = "http://localhost:4200")
     @PutMapping("/resources/edit/{id}")
     public ResponseEntity<Resource> updateResource(@PathVariable(value = "id") Long resourceId,
          @Valid @RequestBody Resource resourceDetails) throws ResourceNotFoundException {
@@ -77,7 +72,6 @@ public class ResourceController {
         return ResponseEntity.ok(updatedResource);
     }
 
-    @CrossOrigin(origins = "http://localhost:4200")
     @DeleteMapping("/resources/{id}")
     public Map<String, Boolean> deleteResource(@PathVariable(value = "id") Long resourceId)
          throws ResourceNotFoundException {

--- a/spring-app/src/main/java/com/burt/resourcemanagement/controller/TeamController.java
+++ b/spring-app/src/main/java/com/burt/resourcemanagement/controller/TeamController.java
@@ -8,7 +8,6 @@ import javax.validation.Valid;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -28,20 +27,17 @@ public class TeamController {
     @Autowired
     private TeamRepository teamRepository;
 
-    @CrossOrigin(origins = "http://localhost:4200")
     @GetMapping("/teams")
     public List<Team> getAllTeams() {
         return teamRepository.findAll();
     }
     
-    @CrossOrigin(origins = "http://localhost:4200")
     @PostMapping("/teams")
     public Team createTeam(@Valid @RequestBody Team team) {
     	team.fixDate();
         return teamRepository.save(team);
     }
 
-    @CrossOrigin(origins = "http://localhost:4200")
     @PutMapping("/teams/edit/{id}")
     public ResponseEntity<Team> updateTeam(@PathVariable(value = "id") Long teamId,
          @Valid @RequestBody Team teamDetails) throws TeamNotFoundException {
@@ -60,7 +56,6 @@ public class TeamController {
         return ResponseEntity.ok(updatedTeam);
     }
 
-    @CrossOrigin(origins = "http://localhost:4200")
     @DeleteMapping("/teams/{id}")
     public Map<String, Boolean> deleteTeam(@PathVariable(value = "id") Long teamId)
          throws TeamNotFoundException {

--- a/spring-app/src/main/resources/application-dev.yml
+++ b/spring-app/src/main/resources/application-dev.yml
@@ -1,0 +1,9 @@
+spring:
+  datasource:
+    url: ${DEV_DB_URL:jdbc:mysql://localhost:3306/resource_db?useUnicode=true&useJDBCCompliantTimezoneShift=true&useLegacyDatetimeCode=false&serverTimezone=UTC}
+    username: ${DEV_DB_USERNAME:root}
+    password: ${DEV_DB_PASSWORD:}
+
+app:
+  cors:
+    allowed-origins: ${DEV_CORS_ALLOWED_ORIGINS:http://localhost:4200}

--- a/spring-app/src/main/resources/application-prod.yml
+++ b/spring-app/src/main/resources/application-prod.yml
@@ -1,0 +1,12 @@
+spring:
+  datasource:
+    url: ${PROD_DB_URL}
+    username: ${PROD_DB_USERNAME}
+    password: ${PROD_DB_PASSWORD}
+  jpa:
+    hibernate:
+      ddl-auto: ${PROD_HIBERNATE_DDL_AUTO:validate}
+
+app:
+  cors:
+    allowed-origins: ${PROD_CORS_ALLOWED_ORIGINS}

--- a/spring-app/src/main/resources/application.properties
+++ b/spring-app/src/main/resources/application.properties
@@ -1,12 +1,7 @@
-spring.datasource.url = jdbc:mysql://localhost:3306/resource_db?useUnicode=true&useJDBCCompliantTimezoneShift=true&useLegacyDatetimeCode=false&serverTimezone=UTC
-spring.datasource.username = root
-spring.datasource.password = Monday12
+spring.profiles.active=${SPRING_PROFILES_ACTIVE:dev}
 
-server.port = 4444
+server.port=${SERVER_PORT:4444}
 
 ## Hibernate Properties
-# The SQL dialect makes Hibernate generate better SQL for the chosen database
-spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.MySQL8Dialect
-
-# Hibernate ddl auto (create, create-drop, validate, update)
-spring.jpa.hibernate.ddl-auto = create-drop
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
+spring.jpa.hibernate.ddl-auto=${SPRING_JPA_HIBERNATE_DDL_AUTO:create-drop}

--- a/spring-app/src/test/java/com/burt/resourcemanagement/DatabaseTest.java
+++ b/spring-app/src/test/java/com/burt/resourcemanagement/DatabaseTest.java
@@ -1,6 +1,6 @@
 package com.burt.resourcemanagement;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNotNull;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -10,25 +10,33 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class DatabaseTest {
-	
-	Connection connection;
 
-	@Before
-	public void setUp() throws Exception {
-		Class.forName("com.mysql.cj.jdbc.Driver");
-		String url = "jdbc:mysql://localhost:3306/resource_db";
-		String user = "root";
-		String password = "Monday12";
-		connection = DriverManager.getConnection(url, user, password);
-	}
+    private static final String DB_URL_ENV = "TEST_DB_URL";
+    private static final String DB_USER_ENV = "TEST_DB_USERNAME";
+    private static final String DB_PASSWORD_ENV = "TEST_DB_PASSWORD";
 
-	@After
-	public void tearDown() throws Exception {
-	}
+    Connection connection;
 
-	@Test
-	public void test() {
-		assertNotNull(connection);
-	}
+    @Before
+    public void setUp() throws Exception {
+        Class.forName("com.mysql.cj.jdbc.Driver");
+        String url = envOrDefault(DB_URL_ENV, "jdbc:mysql://localhost:3306/resource_db");
+        String user = envOrDefault(DB_USER_ENV, "root");
+        String password = envOrDefault(DB_PASSWORD_ENV, "");
+        connection = DriverManager.getConnection(url, user, password);
+    }
 
+    @After
+    public void tearDown() throws Exception {
+    }
+
+    @Test
+    public void test() {
+        assertNotNull(connection);
+    }
+
+    private String envOrDefault(String key, String defaultValue) {
+        String value = System.getenv(key);
+        return value == null || value.trim().isEmpty() ? defaultValue : value;
+    }
 }


### PR DESCRIPTION
### Motivation

- Remove plaintext DB credentials from source and make runtime config environment-driven to reduce secret leaks. 
- Centralize CORS policy so allowed origins are configurable per-environment instead of scattered `@CrossOrigin` annotations. 
- Provide non-secret example env file and docs to guide developers and prevent accidental commits of local `.env` files. 

### Description

- Removed hardcoded credentials from `spring-app/src/main/resources/application.properties` and moved datasource/JPA/CORS settings into profile files `application-dev.yml` and `application-prod.yml` that read from environment variables. 
- Replaced per-method `@CrossOrigin` annotations in controllers with a single `WebConfig` implementing `WebMvcConfigurer` that reads `app.cors.allowed-origins`. 
- Updated `spring-app/src/test/java/com/burt/resourcemanagement/DatabaseTest.java` to read connection values from `TEST_DB_*` environment variables with safe defaults. 
- Added `.env.example` and `docs/configuration.md` documenting required env variables and rotation/git-history guidance, and updated `.gitignore` to ignore local `.env` files while preserving `.env.example`. 

### Testing

- Ran a repository-wide search for remaining hardcoded credentials and CORS annotations using `rg`, which returned only the new example placeholders (no exposed real secrets). 
- Attempted to run `cd spring-app && ./mvnw -q -DskipTests compile`, but the Maven wrapper failed due to network restrictions (`Network is unreachable`). 
- Committed the changes and verified the working tree contains the intended modifications.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea364bad18832aa328a9286a5f2181)