### PR TITLE
ci: upgrade backend workflow to Java 21

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -22,11 +22,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Java 8
+      - name: Set up Java 21
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: '8'
+          java-version: '21'
           cache: maven
 
       - name: Compile


### PR DESCRIPTION
### Motivation
- Upgrade the Java runtime used by backend CI from Java 8 to Java 21 to align the build environment with modern Java versions and project requirements.

### Description
- Updated `.github/workflows/backend-ci.yml` in the `backend-pipeline` job by renaming the step to `Set up Java 21` and setting `with.java-version: '21'` while preserving `distribution: temurin`, `cache: maven`, and the existing `defaults.run.working-directory: spring-app`.

### Testing
- Searched for Java 8 references with `rg` (no remaining matches), reviewed the workflow diff with `git diff`, and committed the change with `git commit`, and all checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea3bf18d5c832ab095ab43f2ad2a13)